### PR TITLE
Added options paramater when constructing Connection from getInstance

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -58,7 +58,7 @@ class Connection implements ConnectionInterface {
 
     if (array_key_exists($name, $instances)) return $instances[$name];
 
-    return $instances[$name] = new self($context, $backend);
+    return $instances[$name] = new self($context, $backend, $options);
   }
 
   //


### PR DESCRIPTION
The options paramater isn't passed to the constructor of the Connection class when initiated from getInstance